### PR TITLE
Change footer in kick/ban message

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -391,13 +391,14 @@ class Moderation:
             embed = discord.Embed(
                 title=f'❗ {command_type} Reason ❗', type='rich')
             footer = 'This is an automated message'
+            custom_footer = footer
             if command_type.lower() == 'ban':
                 command_type = 'bann'
-                footer = await self.bot.pg_utils.get_ban_footer(
+                custom_footer = await self.bot.pg_utils.get_ban_footer(
                     server_id,
                     self.bot.logger)
             elif command_type.lower() == 'kick':
-                footer = await self.bot.pg_utils.get_kick_footer(
+                custom_footer = await self.bot.pg_utils.get_kick_footer(
                     server_id,
                     self.bot.logger)
             elif command_type.lower() == 'unban':
@@ -405,6 +406,8 @@ class Moderation:
             embed.description = f'\nYou were {command_type.lower()}ed '\
                                 f'from **{server_name}**.'
             embed.add_field(name='Reason:', value=reason)
+            if not custom_footer == footer:
+                embed.add_field(name='', value=custom_footer)
             embed.set_footer(text=footer)
             return embed
         except Exception as e:


### PR DESCRIPTION
Potential solution for #1 by adding a variable called `custom_footer` and set it equal to `footer`, change calling `self.bot.pg_utils.get_ban_footer` and `self.bot.pg_utils.get_kick_footer` to set `custom_footer` instead of 'footer`

When you are writing the embed you test to see if `custom_footer` and `footer` are the same, and if they aren't you add a field with no title and the value of the `custom_footer`