### PR TITLE
Feature/wiki

### DIFF
--- a/cogs/info.py
+++ b/cogs/info.py
@@ -1,7 +1,12 @@
 """Cog for giving out useful info: bot invite link, stats, ping, etc."""
-import discord
+
 import datetime
+from os import listdir, getcwd
+from os.path import isfile, join
+
+import discord
 from discord.ext import commands
+
 from .utils import embeds
 
 DISCORD = 'https://discordapp.com/invite/svU3Mdd'
@@ -14,6 +19,40 @@ class Info(commands.Cog):
         """Init method."""
         self.bot = bot
         super().__init__()
+
+    @commands.command(alias=['doc', 'docs'])
+    async def wiki(self, ctx, command: str = None):
+        """Print out a link to docs for yin.
+
+        Parameters
+        ----------
+            command: str
+                The command to search for in the docs.
+
+        """
+        help = """Find the online docs at: <https://dashwav.github.io/yin-bot/"""  # noqa
+        if command is not None:
+            i = 0
+            command = command.lower()
+            mypath = getcwd().split('/')
+            if 'cogs' in mypath:
+                mypath = '/'.join(mypath[0:mypath.index('cogs')]) +\
+                         '/documentation/docs/commands'
+            else:
+                mypath = '/'.join(mypath) + '/documentation/docs/commands'
+            files = [join(mypath, f)
+                     for f in listdir(mypath)
+                     if isfile(join(mypath, f))]
+            while i < len(files) and i != -1:
+                with open(files[i], 'r') as f:
+                    if command in f.read():
+                        command = 'commands/' + files[i].split('/')[-1][:-3]
+                        i = -1
+                    else:
+                        i += 1
+        else:
+            command = ''
+        await ctx.send(help + command + '>.')
 
     @commands.command()
     async def invite(self, ctx):

--- a/cogs/info.py
+++ b/cogs/info.py
@@ -50,6 +50,8 @@ class Info(commands.Cog):
                         i = -1
                     else:
                         i += 1
+            if 'commands/' not in command:
+                command = ''
         else:
             command = ''
         await ctx.send(help + command + '>.')


### PR DESCRIPTION
Issue #76 

Added the new wiki command. It has aliases doc and docs
`-wiki` will just link to the yinbot webpage.
if an argument is provided and is found within one of the doc pages then will link to that page.
`-wiki voiceroles` will link to the appropriate page. 
If an argument is not found in the doc files it will just relink to the base page.